### PR TITLE
Add chart titles and reduce size

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,9 +111,9 @@
 </section>
 
     <section id="charts" class="panel" style="margin-top:14px;padding:16px">
-      <canvas id="chartDistance"></canvas>
-      <canvas id="chartGo" style="margin-top:20px"></canvas>
-      <canvas id="chartBack" style="margin-top:20px"></canvas>
+      <canvas id="chartDistance" height="220"></canvas>
+      <canvas id="chartGo" height="220" style="margin-top:20px"></canvas>
+      <canvas id="chartBack" height="220" style="margin-top:20px"></canvas>
     </section>
 
     <section id="results" class="list" aria-live="polite"></section>
@@ -179,13 +179,13 @@ function updateCharts(rows){
   const go = rows.map(s=>s.time_peak8_min);
   const back = rows.map(s=>s.time_peak15_min);
   document.getElementById('charts').style.display = rows.length? 'block':'none';
-  const common = {indexAxis:'y',responsive:true,plugins:{legend:{display:false}},scales:{x:{beginAtZero:true}}};
+  const common = {indexAxis:'y',responsive:true,maintainAspectRatio:false,plugins:{legend:{display:false}},scales:{x:{beginAtZero:true}}};
   if(chartDist){ chartDist.data.labels=labels; chartDist.data.datasets[0].data=dist; chartDist.update(); }
   else{
     chartDist = new Chart(document.getElementById('chartDistance'),{
       type:'bar',
       data:{labels,datasets:[{label:'ระยะทาง (กม.)',data:dist,backgroundColor:'rgba(91,209,255,0.7)'}]},
-      options:common
+      options:{...common,plugins:{...common.plugins,title:{display:true,text:'ระยะทาง (กม.)'}}}
     });
   }
   if(chartGo){ chartGo.data.labels=labels; chartGo.data.datasets[0].data=go; chartGo.update(); }
@@ -193,7 +193,7 @@ function updateCharts(rows){
     chartGo = new Chart(document.getElementById('chartGo'),{
       type:'bar',
       data:{labels,datasets:[{label:'ไป 08:00 (นาที)',data:go,backgroundColor:'rgba(133,240,137,0.7)'}]},
-      options:common
+      options:{...common,plugins:{...common.plugins,title:{display:true,text:'ไป 08:00 (นาที)'}}}
     });
   }
   if(chartBack){ chartBack.data.labels=labels; chartBack.data.datasets[0].data=back; chartBack.update(); }
@@ -201,7 +201,7 @@ function updateCharts(rows){
     chartBack = new Chart(document.getElementById('chartBack'),{
       type:'bar',
       data:{labels,datasets:[{label:'กลับ 15:00 (นาที)',data:back,backgroundColor:'rgba(255,209,102,0.7)'}]},
-      options:common
+      options:{...common,plugins:{...common.plugins,title:{display:true,text:'กลับ 15:00 (นาที)'}}}
     });
   }
 }


### PR DESCRIPTION
## Summary
- Reduce chart height for distance, go, and back canvases
- Add descriptive titles to distance, go, and back charts
- Set charts to ignore aspect ratio for consistent sizing

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b381a0bf08321bfa0825e8f81d71b