### PR TITLE
Limit panel cards to two per row

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,8 @@
   button{cursor:pointer}
   .chips{display:flex;flex-wrap:wrap;gap:6px}
   .chip{padding:6px 10px;border-radius:999px;background:var(--chip);border:1px solid rgba(255,255,255,0.08);font-size:12px;color:#cfe3ff}
-  .list{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:10px;margin-top:14px;font-size:14px}
+  .list{display:grid;grid-template-columns:1fr;gap:10px;margin-top:14px;font-size:14px}
+  @media(min-width:720px){.list{grid-template-columns:repeat(2,1fr)}}
   .card{position:relative;padding:10px;display:flex;flex-direction:column;gap:8px}
   .title{font-weight:700;display:flex;align-items:center;gap:12px}
   .meta{display:flex;gap:10px;flex-wrap:wrap;color:var(--muted);font-size:13px}


### PR DESCRIPTION
## Summary
- Restrict card list grid to one column by default and two columns on wider screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b6128bfc48321b054cf5b60ba5014